### PR TITLE
디자인 및 편의사항 수정작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-recorder-viewer",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "MIT",
   "scripts": {
     "start:dev": "razzle start",

--- a/src/components/chart/pie/Donut.tsx
+++ b/src/components/chart/pie/Donut.tsx
@@ -18,7 +18,7 @@ export default class ChartPieDonut extends React.Component<IChartBarStacked2Prop
     return (
       <Doughnut
         data={{labels: this.props.labels, datasets: this.props.datasets}}
-        options={{ legend: { position: 'bottom' } }}
+        options={{ legend: { position: 'left' } }}
         width={this.props.width}
         height={this.props.height}
       />

--- a/src/components/common/DefaultHeader.tsx
+++ b/src/components/common/DefaultHeader.tsx
@@ -81,7 +81,7 @@ class DefaultHeader extends React.Component<IDefaultHeaderProps, IDefaultHeaderS
             width="30"
             height="30"
             alt="Work Logger"
-            className="navbar-brand-minimized"
+            className="navbar-brand-minimized clickable"
             onClick={() => { window.location.href = '/'; }}
           />
           <Nav className="ml-auto" navbar={true}>

--- a/src/components/group/info/container.tsx
+++ b/src/components/group/info/container.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import {
-    Button, Card, CardBody, CardFooter, CardHeader, CardTitle, Col, Container, Row, Table
+    Button, Card, CardBody, CardFooter, CardHeader, CardTitle, Container, ListGroup, ListGroupItem
 } from 'reactstrap';
 
 import { Group } from '../../../models/group/Group';
@@ -76,20 +76,20 @@ export default class GroupInfoContainer extends React.Component<IGroupInfoContai
     return this.props.groupInfos
     .map((mv) => {
       return (
-        <tr
+        <ListGroupItem
           key={mv.group_id}
         >
-          <td>
+          <span>
             {mv.desc}
-          </td>
-          <td>
+          </span>
+          <span className="list-group-button">
             <Button
               onClick={() => { this.handleClickGotoGroup(mv.group_id); }}
             >
               로그확인
             </Button>
-          </td>
-        </tr>
+          </span>
+        </ListGroupItem>
       );
     });
   }
@@ -131,14 +131,9 @@ export default class GroupInfoContainer extends React.Component<IGroupInfoContai
                 그룹 목록
               </CardHeader>
               <CardBody>
-                <Table
-                  responsive={true}
-                  className="d-sm-table"
-                >
-                  <tbody>
-                    {rows}
-                  </tbody>
-                </Table>
+                <ListGroup>
+                  {rows}
+                </ListGroup>
               </CardBody>
             </Card>
           </Container>

--- a/src/components/record/container.tsx
+++ b/src/components/record/container.tsx
@@ -416,6 +416,7 @@ IRecordContainerStates & IetcStates   > {
         return (
           <tr
             key={mv}
+            className="clickable"
             onClick={() => { this.handleOnClickSingleDayTableRow(mv, tData); }}
           >
             <td>{EN_WORK_TITLE_KR[tData.type]}</td>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,0 +1,2 @@
+.clickable {
+  cursor: pointer; }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -3,3 +3,13 @@
 
 .clickable {
   cursor: pointer; }
+
+.list-group-item .list-group-button {
+  position: absolute;
+  top: 50%;
+  right: 1.25rem;
+  margin-top: -1.1rem;
+}
+
+.chart-wrapper {
+  margin-bottom: 1rem; }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,2 +1,5 @@
+.app-body .container {
+  padding-top: 1.5rem; }
+
 .clickable {
   cursor: pointer; }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -9859,3 +9859,5 @@ body {
 
 html body .app.flex-row.align-items-center {
   height: 100vh; }
+
+@import './custom.css';


### PR DESCRIPTION
> 이 내용은 @todayears 님에 의한 것으로 이곳에도 옮겨둔다.
# 작업 된 내용

## 1. 공통 헤더 로고와 나의 오늘 기록 Row Clickable하게 보이도록 수정

기존에는 Clickable한 영역인지 쉽게 구분이 안가 사용자 경험을 떨어트리는 요소라 판단하여 수정함

![2018-09-19 1](https://user-images.githubusercontent.com/23294462/45731377-405bee80-bc12-11e8-857e-28ab6197650b.png)

## 2. Donut 컴포넌트 옵션 변경

나의 오늘 기록을 시각적으로 표현하던 도넛 차트의 요소 리스트가 많아짐에 따라
나열이 흐트러져 시각적으로 좋지 못하다 생각되어 좌측 정렬로 수정하였다.

### 기존 PC 모습
---
![2018-09-19 1 22 08](https://user-images.githubusercontent.com/23294462/45731421-7d27e580-bc12-11e8-958d-c5587d719473.png)

### 기존 모바일 모습
---
![2018-09-19 1 22 29](https://user-images.githubusercontent.com/23294462/45731429-8add6b00-bc12-11e8-9399-68f04ba0fd56.png)

### 수정된 PC 모습
---
![2018-09-19 1 21 53](https://user-images.githubusercontent.com/23294462/45731435-93ce3c80-bc12-11e8-84b4-4667e1941196.png)

### 수정된 모바일 모습
---
![2018-09-19 1 22 18](https://user-images.githubusercontent.com/23294462/45731444-9cbf0e00-bc12-11e8-8759-ae5c6ba5d2f2.png)


## 3. 전체 영역에서 app-body 안 Container 에 상단패딩 추가

전체 영역에서 .app-body > .container 와 같은 구조인데
상단 패딩이 적용되어 있지 않아 공통 헤더와 딱붙어 답답한 느낌을 주기 때문에 전체적으로 적용

### 변경 전 모습
---
![2018-09-19 1 50 57](https://user-images.githubusercontent.com/23294462/45731562-21aa2780-bc13-11e8-9d8e-1d7b10cc270f.png)

### 변경 후 모습
---
![2018-09-19 1 51 20](https://user-images.githubusercontent.com/23294462/45731567-28389f00-bc13-11e8-852c-e6126bf47bf7.png)

## 4. 그룹 목록에서 table->list 로 변경 후 스타일 수정

정보 구성 상 table보다 list에 더 가깝다는 생각이 들었고,
위 처럼 변경했을때 반응형 대응이 더 쉽고 미려하게 되기 때문에 수정하였다.


### 변경 전 PC 모습
---
![2018-09-19 1 15 48](https://user-images.githubusercontent.com/23294462/45731605-69c94a00-bc13-11e8-83df-9132daa5ac9b.png)

### 변경 후 PC 모습
---
![2018-09-19 1 15 03](https://user-images.githubusercontent.com/23294462/45731615-764da280-bc13-11e8-9017-24e52769a770.png)

### 변경 전 모바일 모습
---
![2018-09-19 1 17 52](https://user-images.githubusercontent.com/23294462/45731622-7ea5dd80-bc13-11e8-983b-2b52a2b49330.png)

### 변경 후 모바일 모습
---
![2018-09-19 1 17 59](https://user-images.githubusercontent.com/23294462/45731633-8b2a3600-bc13-11e8-8681-149b7716d861.png)
