### PR TITLE
QueueStore 수정

### DIFF
--- a/src/stores/QueueStore.ts
+++ b/src/stores/QueueStore.ts
@@ -87,9 +87,7 @@ export default class QueueStore {
 
       return runInAction(() => {
         this.isLoading = false;
-        if (Util.isNotEmpty(deleteResp.data)) {
-          this.queue = deleteResp.data;
-        }
+        this.queue = Util.isNotEmpty(deleteResp.data) ? deleteResp.data : [];
         return this.queue;
       });
     } catch (error) {


### PR DESCRIPTION
* deleteQueue 액션이 발생할 때 마지막 큐가 삭제되면 리스트가 갱신되지 않는 문제 수정
  * 원인: 빈 array일 때 queue를 갱신하지 않음
  * 해결: 빈 array 반환 시도 queue에 넣도록 수정