### PR TITLE
탭 이름 변경 및 커피타임 총 인원 수 뱃지 추가

### DIFF
--- a/src/components/coffee/add/container.tsx
+++ b/src/components/coffee/add/container.tsx
@@ -6,7 +6,14 @@ import { produce } from 'immer';
 import { observer } from 'mobx-react';
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { Button, Card, CardBody, CardHeader, Container } from 'reactstrap';
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Container
+} from 'reactstrap';
 
 import { Group } from '../../../models/group/Group';
 import { GroupRequestBuilder } from '../../../models/group/GroupRequestBuilder';
@@ -266,7 +273,7 @@ export default class CoffeeAddContainer extends React.Component<IProp, IState> {
     return (
       <div className="app">
         <Helmet>
-          <title>test</title>
+          <title>☕️⏱</title>
         </Helmet>
         <DefaultHeader
           isLogin={this.isLogined()}
@@ -288,7 +295,9 @@ export default class CoffeeAddContainer extends React.Component<IProp, IState> {
             </Card>
             {this.state.step !== 2 ? null : (
               <Card>
-                <CardHeader>참가자 목록</CardHeader>
+                <CardHeader>
+                  참가자 목록 <Badge>총 {userList.length} 명</Badge>
+                </CardHeader>
                 <CardBody>{userList}</CardBody>
               </Card>
             )}

--- a/src/components/coffee/container.tsx
+++ b/src/components/coffee/container.tsx
@@ -129,7 +129,7 @@ export default class CoffeeContainer extends React.Component<IProp, IState> {
     return (
       <div className="app">
         <Helmet>
-          <title>test</title>
+          <title>☕️⏱</title>
         </Helmet>
         <DefaultHeader
           isLogin={this.isLogined()}

--- a/src/components/coffee/detail/container.tsx
+++ b/src/components/coffee/detail/container.tsx
@@ -482,7 +482,7 @@ export default class CoffeeDetailContainer extends React.Component<
             await this.detailStore.sendMsgToGuests();
           }}
         >
-          참석자에게 주문 요청하기
+          참가자에게 주문 요청하기
         </Button>,
         <Button
           key="close_btn"
@@ -507,8 +507,7 @@ export default class CoffeeDetailContainer extends React.Component<
   private getGuestsItem() {
     if (
       Util.isNotEmpty(this.detailStore) &&
-      Util.isNotEmpty(this.detailStore.Users) &&
-      this.state.toggleUserList === true
+      Util.isNotEmpty(this.detailStore.Users)
     ) {
       const userResult = [...this.detailStore.Users.values()].map(mv => {
         return (
@@ -618,6 +617,9 @@ export default class CoffeeDetailContainer extends React.Component<
         로그인
       </Button>
     );
+    const guestCountBadge =
+      guestItems === null ? null : <Badge> 총 {guestItems.length} 명 </Badge>;
+
     return (
       <div className="app">
         <Helmet>
@@ -669,15 +671,20 @@ export default class CoffeeDetailContainer extends React.Component<
             </Card>
             <Card>
               <CardHeader>
+                참가자 목록 {guestCountBadge}{' '}
                 <Button
+                  outline={true}
+                  size="sm"
                   onClick={() => {
                     this.toggleGuestList();
                   }}
                 >
-                  참가자 목록 {this.state.toggleUserList ? '닫기' : '열기'}
+                  {this.state.toggleUserList ? '닫기' : '열기'}
                 </Button>
               </CardHeader>
-              <CardBody>{guestItems}</CardBody>
+              <CardBody>
+                {this.state.toggleUserList === true ? guestItems : null}
+              </CardBody>
             </Card>
           </Container>
           <Modal isOpen={this.state.isOpenAddBeverage}>

--- a/src/components/record/container.tsx
+++ b/src/components/record/container.tsx
@@ -1244,10 +1244,14 @@ class RecordContainer extends React.Component<
     const modalBody = this.getModalBody();
     const fuseModalBody = this.getFuseModalBody();
     const fuseToVacationModalBody = this.getFuseToVacationModalBody();
+    const name =
+      this.props.userInfo === null
+        ? this.props.userId
+        : this.props.userInfo.real_name;
     return (
       <div className="app">
         <Helmet>
-          <title>User {this.props.userId} Work Log</title>
+          <title>{name} Work Log</title>
         </Helmet>
         <DefaultHeader
           isLogin={this.isLogined()}


### PR DESCRIPTION
1. test로 되어 있는 탭 이름을 커피타임으로 변경
2. 오늘 기록을 누르면 나오는 탭 이름은 userId -> real_name 기준으로 변경
3. 커피타임 참석자 수를 보여주는 뱃지 추가

## 결과
1.
### 이전
![image](https://user-images.githubusercontent.com/32254667/67036906-704c2d00-f157-11e9-8387-46d013fd85bb.png)

### 이후
![image](https://user-images.githubusercontent.com/32254667/67036861-57437c00-f157-11e9-89db-e0e41d564cbe.png)

2.
### 이전
![image](https://user-images.githubusercontent.com/32254667/67036797-38dd8080-f157-11e9-8ccb-dfcfe9913a57.png)

### 이후
![image](https://user-images.githubusercontent.com/32254667/67036742-1d727580-f157-11e9-8cca-2d20f47e0173.png)

3.
### 이전
![image](https://user-images.githubusercontent.com/32254667/67216964-038aa880-f45f-11e9-820d-5a5074c34d65.png)


![image](https://user-images.githubusercontent.com/32254667/67036594-dab09d80-f156-11e9-8403-f6b2da4117b1.png)

### 이후
![image](https://user-images.githubusercontent.com/32254667/67217046-1dc48680-f45f-11e9-8896-36bba557cd3b.png)

![image](https://user-images.githubusercontent.com/32254667/67036295-4f370c80-f156-11e9-99dd-17cbed5f85df.png)