### PR TITLE
그룹 리스트 아이템 hover 스타일 제거

### DIFF
--- a/src/components/group/container.tsx
+++ b/src/components/group/container.tsx
@@ -759,7 +759,7 @@ export default class GroupContainer extends React.Component<
                 ) : null}
               </CardHeader>
               <CardBody>
-                <Table responsive={true} className="d-sm-table" hover={true}>
+                <Table responsive={true} className="d-sm-table" hover={false}>
                   <thead className="thead-light">
                     <tr>
                       <th className="text-center">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3620,9 +3620,6 @@ input[type="button"].btn-block {
     margin-bottom: 0;
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem; }
-  .list-group-item:hover, .list-group-item:focus {
-    z-index: 1;
-    text-decoration: none; }
   .list-group-item.disabled, .list-group-item:disabled {
     color: #73818f;
     background-color: #fff; }


### PR DESCRIPTION
Co-authored-by: alattalatta <urty5656@gmail.com>
Co-authored-by: mindock <parksy8189@gmail.com>

마우스가 올라가있는 아이템 밑을 가리는 스타일이 들어가서 제거하였습니다.

<img width="525" alt="스크린샷 2019-11-21 오후 1 19 13" src="https://user-images.githubusercontent.com/29939590/69305255-9ab56c80-0c66-11ea-977c-8819e890a0ef.png">
