### PR TITLE
start 스크립트 복구

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:debug": "razzle start --inspect",
     "build": "razzle build",
     "test": "razzle test --env=jsdom",
-    "start": "$env:NODE_ENV=\"production\" node ./build/server.js",
+    "start": "NODE_ENV=production node ./build/server.js",
     "start:onlinux": "npm run build && NODE_ENV=production pm2 start build/server.js -i 2 --name YAWORK_WEB",
     "dist": "node dist.js",
     "lint": "tslint -c tslint.json \"src/**/*.ts*\""


### PR DESCRIPTION
왜 충돌 해소를 했는데 안올라가있지? 했었는데, 집에서 push를 안했었습니다...
그 과정에서 Windows 환경변수로 바꿔놨던 `start` 스크립트를 다시 복구합니다.